### PR TITLE
Ensure card stack recomputes on profile updates

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -569,7 +569,7 @@ const DiscoverScreen = ({ profile, allNames, updateProfile, origins }) => {
             return !profile.seenNames.includes(n.id) && genderMatch && originMatch && lengthMatch;
         });
         return [...potentialNames].sort(() => Math.random() - 0.5);
-    }, [filter, allNames, profile.id]);
+    }, [filter, allNames, profile.likedNames, profile.seenNames]);
 
     useEffect(() => { setCardStack(memoizedCardStack); setCurrentIndex(0); }, [memoizedCardStack]);
 


### PR DESCRIPTION
## Summary
- Recompute card stack when liked or seen names change

## Testing
- `npm test -- --watchAll=false` (fails: TestingLibraryElementError: Unable to find an element with the text: /Tableau de Bord/i)


------
https://chatgpt.com/codex/tasks/task_e_68b02db9c6a48333a75afdef19ce42ba