### PR TITLE
Disable Android backup feature

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -2,7 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
-        android:allowBackup="true"
+        android:allowBackup="false"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"


### PR DESCRIPTION
## Summary
- disable Android backup by setting `android:allowBackup` to false

## Testing
- `./gradlew assembleDebug` *(fails: Unable to tunnel through proxy 403 Forbidden)*
- `CI=true npm test` *(fails: FirebaseError auth/invalid-api-key)*

------
https://chatgpt.com/codex/tasks/task_e_68b090a6b0dc833380ce75ef166d52a0