### PR TITLE
feat: add storage abstraction

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -27,6 +27,7 @@ import {
 } from 'firebase/firestore';
 // --- CORRECTION DE L'IMPORT POUR LE PLUGIN SOCIAL LOGIN ---
 import { SocialLogin } from '@capgo/capacitor-social-login';
+import { storage } from './storage';
 
 
 // --- CONFIGURATION FIREBASE (REMPLIR AVEC VOS INFORMATIONS) ---
@@ -163,11 +164,10 @@ const pageTitles = {
     detail: 'Détail du Prénom',
 };
 
-const getInitialTheme = () => {
-    if (typeof window !== 'undefined' && window.localStorage) {
-        const storedTheme = window.localStorage.getItem('name_app_theme_v2');
-        if (storedTheme === 'dark' || storedTheme === 'light') return storedTheme;
-    }
+
+const getInitialTheme = async () => {
+    const storedTheme = await storage.getItem('name_app_theme_v2');
+    if (storedTheme === 'dark' || storedTheme === 'light') return storedTheme;
     return 'light';
 };
 
@@ -193,7 +193,11 @@ const AppLayout = () => {
     const [userData, setUserData] = useState(null);
     const [currentPage, setCurrentPage] = useState('dashboard');
     const [detailedName, setDetailedName] = useState(null);
-    const [theme, setTheme] = useState(getInitialTheme);
+    const [theme, setTheme] = useState('light');
+
+    useEffect(() => {
+        getInitialTheme().then(setTheme);
+    }, []);
 
     // State for friends, requests, etc.
     const [friends, setFriends] = useState([]);
@@ -205,7 +209,7 @@ const AppLayout = () => {
         const root = window.document.documentElement;
         root.classList.remove(theme === 'dark' ? 'light' : 'dark');
         root.classList.add(theme);
-        localStorage.setItem('name_app_theme_v2', theme);
+        storage.setItem('name_app_theme_v2', theme);
     }, [theme]);
 
     const uniqueOrigins = useMemo(() => {

--- a/src/storage.js
+++ b/src/storage.js
@@ -1,0 +1,24 @@
+import { Capacitor } from '@capacitor/core';
+
+const preferences = Capacitor.Plugins?.Preferences;
+const isNative = Capacitor.isNativePlatform();
+
+export const storage = {
+  async getItem(key) {
+    if (isNative && preferences) {
+      const { value } = await preferences.get({ key });
+      return value ?? null;
+    }
+    if (typeof window !== 'undefined' && window.localStorage) {
+      return window.localStorage.getItem(key);
+    }
+    return null;
+  },
+  async setItem(key, value) {
+    if (isNative && preferences) {
+      await preferences.set({ key, value });
+    } else if (typeof window !== 'undefined' && window.localStorage) {
+      window.localStorage.setItem(key, value);
+    }
+  }
+};


### PR DESCRIPTION
## Summary
- create capacitor-aware storage wrapper
- use storage wrapper for theme persistence

## Testing
- `CI=true npm test` (fails: Firebase error auth/invalid-api-key)
- `npm run build`
- `npx cap sync android`


------
https://chatgpt.com/codex/tasks/task_e_68b0996bd2388333beb4cc04d6d73711